### PR TITLE
Multi sessions

### DIFF
--- a/CQORCcalendar.py
+++ b/CQORCcalendar.py
@@ -1,3 +1,4 @@
+import os
 import interfaces.google.GSheetsInterface as GSheetsInterface
 
 class Calendar:
@@ -26,7 +27,7 @@ class Calendar:
 
     # equivalent of former events_from_sheet_calendar
     def get_all_sessions(self):
-        return [session for session in course['sessions'] for course in self.courses]
+        return [session for course in self.courses for session in course['sessions']]
 
     def keys():
         return self.courses.keys()

--- a/CQORCcalendar.py
+++ b/CQORCcalendar.py
@@ -1,0 +1,60 @@
+import interfaces.google.GSheetsInterface as GSheetsInterface
+
+class Calendar:
+    def __init__(self, global_config, args):
+        # take the credentials file either from google section
+        credentials_file = global_config['google']['credentials_file']
+        secrets_dir = os.environ.get('CQORC_SECRETS_DIR', args.secrets_dir)
+        credentials_file_path = os.path.join(secrets_dir, credentials_file)
+
+        # initialize the Google Drive interface
+        self.gsheets = GSheetsInterface.GSheetsInterface(credentials_file_path)
+
+        self.spreadsheet_id = global_config['google']['calendar_file']
+        self.sheet_name = global_config['google']['calendar_sheet_name']
+        list_of_sessions = self.gsheets.get_values(self.spreadsheet_id, "A:Z", self.sheet_name)
+        self.header = list_of_sessions[0]
+        sessions = [{header[i]: item[i] if i < len(item) else None for i in range(len(header))} for item in list_of_sessions[1:]]
+
+        self.courses = {}
+        for session in sessions:
+            course_id = session['course_id']
+            if course_id not in courses:
+                self.courses[course_id] = {'sessions': []}
+
+            self.courses[session['id']]['sessions'] += session
+
+    # equivalent of former events_from_sheet_calendar
+    def get_all_sessions(self):
+        return [session for session in course['sessions'] for course in self.courses]
+
+    def keys():
+        return self.courses.keys()
+
+    def items():
+        return self.courses.items()
+
+    def __getitem__(self, course_id):
+        return self.courses[course_id]
+
+    def set_eventbrite_id(self, course_id, eventbrite_id):
+        for session in self.courses['sessions']:
+            session['eventbrite_id'] = eventbrite_id
+
+    def set_zoom_id(self, course_id, zoom_id):
+        for session in self.courses['sessions']:
+            session['zoom_id'] = zoom_id
+
+    def set_slack_channel(self, course_id, slack_channel):
+        for session in self.courses['sessions']:
+            session['slack_channel'] = slack_channel
+
+    def update_spreadsheet(self):
+        values = [self.header]
+        for course in self.courses:
+            for session in course['sessions']:
+                session_line = [session[k] for k in self.header]
+                values += [session_line]
+
+        self.gsheets.update_values(self, self.spreadsheet_id, "A:Z", values, self_sheet_name)
+

--- a/CQORCcalendar.py
+++ b/CQORCcalendar.py
@@ -29,10 +29,13 @@ class Calendar:
     def get_all_sessions(self):
         return [session for course in self.courses for session in course['sessions']]
 
-    def keys():
+    def get_courses(self):
+        return self.courses.values()
+
+    def keys(self):
         return self.courses.keys()
 
-    def items():
+    def items(self):
         return self.courses.items()
 
     def __getitem__(self, course_id):

--- a/common.py
+++ b/common.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import interfaces.google.GSheetsInterface as GSheetsInterface
 import argparse, configparser, os, glob
 import urllib
 import yaml
@@ -72,20 +71,6 @@ def get_survey_link(config, locale, title, date):
     survey_template = config['survey'][f"survey_link_template_{locale}"]
     link = eval('f' + repr(survey_template))
     return link
-
-def get_events_from_sheet_calendar(global_config, args):
-    # take the credentials file either from google section
-    credentials_file = global_config['google']['credentials_file']
-    secrets_dir = os.environ.get('CQORC_SECRETS_DIR', args.secrets_dir)
-    credentials_file_path = os.path.join(secrets_dir, credentials_file)
-
-    # initialize the Google Drive interface
-    gsheets = GSheetsInterface.GSheetsInterface(credentials_file_path)
-
-    list_of_events = gsheets.get_values(global_config['google']['calendar_file'], "A:Z", global_config['google']['calendar_sheet_name'])
-    header = list_of_events[0]
-    dict_of_events = [{header[i]: item[i] if i < len(item) else None for i in range(len(header))} for item in list_of_events[1:]]
-    return dict_of_events
 
 def actualize_repo(url, local_repo):
     """

--- a/config.cfg
+++ b/config.cfg
@@ -19,6 +19,8 @@ message_survey_template = <!channel>: N'oubliez pas de poster le sondage: {surve
 message_survey_multidays = True
 # message_2 in secrets config file
 message_bienvenue_offset_now = 1
+message_bienvenue_multidays = False
+# message_2 in secrets config file
 message_bienvenue_template = Bienvenue sur le canal pour la formation {course_code} du {start_time.date()}
    Je suis votre robot assistant et je posterai des messages pertinents à des moments pertinents (ou du moins, je l'espère).
    Des signets avec les liens utiles ont été ajoutés au canal.
@@ -33,4 +35,4 @@ local_repo=descriptions
 
 [eventbrite]
 close_hours_before_event = 12
-registration_url = https://www.eventbrite.ca/e/{eb_event['id']}
+registration_url = https://www.eventbrite.ca/e/{eb_event_id}

--- a/eventbrite_manager.py
+++ b/eventbrite_manager.py
@@ -1,0 +1,171 @@
+import argparse
+import yaml
+from datetime import datetime, timedelta, timezone
+import os
+import re
+from git import Repo
+from bs4 import BeautifulSoup
+import configparser
+from glob import glob
+import interfaces.eventbrite.EventbriteInterface as eventbrite
+from common import UTC_FMT, valid_date, to_iso8061, ISO_8061_FORMAT, Trainers, get_config
+import CQORCcalendar
+
+
+def actualize_repo(url, local_repo):
+    """
+    Clones or pulls the repo at `url` to `local_repo`.
+    """
+    repo = (
+        Repo(local_repo)
+        if os.path.exists(local_repo)
+        else Repo.clone_from(url, local_repo)
+    )
+    # pull in latest changes if any, expects remote to be named `origin`
+    repo.remotes.origin.pull()
+
+
+def update_html(description, content, instructor_name):
+    """
+    Updates the HTML description with the content and instructor.
+
+    The HTML description is a template with the following tags:
+        [[SUMMARY]]
+        [[DESCRIPTION]]
+        [[PREREQS]]
+        [[PLAN]]
+        [[INSTRUCTOR]]
+
+    The content is a dictionary with the following keys:
+        summary
+        description
+        prerequisites
+        plan
+    """
+    soup = BeautifulSoup(description, "html.parser")
+
+    # Find elements!
+
+    # Remove the summary which is not used
+    summary = soup.select_one("div")
+    summary.decompose()
+
+    desc = soup.find("p", string="[[DESCRIPTION]]")
+    prerequis = soup.find("p", string="[[PREREQS]]")
+    plan = soup.find("p", string="[[PLAN]]")
+    instructor = soup.find("p", string=re.compile("\\[\\[INSTRUCTOR\\]\\]"))
+
+    # Update them
+    # summary.string = summary.string.replace("[[SUMMARY]]", content["summary"])
+    desc.string = desc.string.replace("[[DESCRIPTION]]", content["description"])
+
+    new_prereqs = soup.new_tag("ul")
+    for i in content["prerequisites"]:
+        new_li = soup.new_tag("li")
+        new_li.string = i
+        new_prereqs.append(new_li)
+    prerequis.replace_with(new_prereqs)
+
+    new_plan = soup.new_tag("ul")
+    for i in content["plan"]:
+        new_li = soup.new_tag("li")
+        new_li.string = i
+        new_plan.append(new_li)
+    plan.replace_with(new_plan)
+
+    # Update instructor
+    instructor.string = instructor.string.replace("[[INSTRUCTOR]]", instructor_name)
+
+    return soup
+
+if __name__ == "__main__":
+
+    config = configparser.ConfigParser()
+
+    parser = argparse.ArgumentParser(description="Create a new event from a template.")
+
+    parser.add_argument("--config_dir", default=".", help="Directory that holds the configuration files")
+    parser.add_argument("--secrets_dir", default=".", help="Directory that holds the configuration files")
+    parser.add_argument("--date", metavar=ISO_8061_FORMAT, type=valid_date, help="Generate for the first event on this date")
+    parser.add_argument("--course_id", help="Handle course specified by course_id")
+    parser.add_argument("--dry-run", default=False, action='store_true', help="Dry-run")
+    parser.add_argument("--create", default=False, action='store_true', help="Create event")
+    parser.add_argument("--update", default=False, action='store_true', help="Update event")
+    parser.add_argument("--delete", default=False, action='store_true', help="Delete event")
+
+    args = parser.parse_args()
+    print(vars(args))
+
+    config = get_config(args)
+    trainers = Trainers(config['global']['trainers_db'])
+    # no need to actualize the repo if we are not creating or updating the event
+    if args.create or args.update:
+        actualize_repo(config["descriptions"]["repo_url"], config["descriptions"]["local_repo"])
+    eb = eventbrite.EventbriteInterface(config["eventbrite"]["api_key"])
+
+    # get the courses from the working calendar in the Google spreadsheets
+    calendar = CQORCcalendar.Calendar(config, args)
+    courses = calendar.get_courses()
+
+    # keep only courses that start on the date listed
+    if args.date:
+        courses = [courses for course in courses if args.date.date().isoformat() in course['sessions'][0]['start_date']]
+    # keep only the course for the course_id specified
+    if args.course_id:
+        courses = [calendar[args.course_id]]
+
+    for course in courses:
+        first_session = course['sessions'][0]
+        instructor = ','.join([trainers.fullname(session['instructor']) for session in course['sessions']])
+
+        if first_session['code']:
+            # Read the description from the repo
+            with open(os.path.join(config["descriptions"]["local_repo"], f"{first_session['code']}-{first_session['langue']}.yaml")) as f:
+                event_description = yaml.safe_load(f)
+        else:
+            event_description = None
+            print("Empty workshop code, skipping updating description")
+
+        # Create the event
+        if args.create:
+            # for multi-session courses, the duration of the webinar must be from the start to the end
+            start_date = min([to_iso8061(session['start_date']) for session in course['sessions']])
+            end_date = max([to_iso8061(session['end_date']) for session in course['sessions']])
+
+            eventid = eb.create_event_from(
+                event_id=first_session['template'],
+                title=first_session['title'],
+                start_date=start_date,
+                end_date=end_date,
+                tz=config["global"]["timezone"],
+                summary=event_description["summary"] if event_description else "",
+            )
+            calendar.set_eventbrite_id(first_session['course_id'], eventid)
+            print(f"Successfully created {first_session['title']}({eventid}) {start_date} {end_date}")
+        else:
+            eventid = first_session['eventbrite_id']
+
+
+        # Update the event
+        if args.update or args.create:
+            if event_description:
+                # Update the description
+                eb.update_event_description(eventid, str(update_html(
+                    eb.get_event_description(eventid)['description'],
+                    event_description,
+                    instructor,
+                )))
+                print(f'Successfully updated {eventid} description')
+
+            # Update tickets classes
+            hours = int(config["eventbrite"]["close_hours_before_event"])
+            eb.update_tickets(eventid, "", (to_iso8061(first_session['start_date']) - timedelta(hours=hours)).astimezone(timezone.utc).strftime(UTC_FMT))
+            print(f'Successfully updated {eventid} ticket classes')
+
+        # Delete the event
+        if args.delete:
+            eb.delete_event(eventid)
+            calendar.set_eventbrite_id(first_session['course_id'], '')
+            print(f'Successfully deleted {eventid}')
+
+    calendar.update_spreadsheet()

--- a/gcal_events.py
+++ b/gcal_events.py
@@ -3,7 +3,7 @@ import os, argparse, datetime
 
 import interfaces.zoom.ZoomInterface as ZoomInterface
 import interfaces.google.GCalInterface as GCalInterface
-from CQORCcalendar import Calendar
+import CQORCcalendar
 
 from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
@@ -11,6 +11,7 @@ from common import Trainers
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--date", metavar=ISO_8061_FORMAT, type=valid_date, help="Generate for the first event on this date")
+parser.add_argument("--course_id", help="Generate events for the course specified by the course_id")
 parser.add_argument("--config_dir", default=".", help="Directory that holds the configuration files")
 parser.add_argument("--secrets_dir", default=".", help="Directory that holds the configuration files")
 parser.add_argument("--all", default=False, action='store_true', help="Act for all events")
@@ -36,11 +37,15 @@ zoom = ZoomInterface.ZoomInterface(config['zoom']['account_id'], config['zoom'][
 start_offset_minutes = int(config['google.calendar']['start_offset_minutes'])
 
 # get the events from the working calendar in the Google spreadsheets
-sessions = Calendar(config, args).get_all_sessions()
+calendar = CQORCcalendar.Calendar(config, args)
+sessions = calendar.get_all_sessions()
 
 # keep only sessions on the date listed
 if args.date:
     sessions = [session for session in sessions if args.date.date().isoformat() in session['start_date']]
+# keep only sessions for the given course_id
+if args.course_id:
+    sessions = [session for session in sessions if args.course_id == session['course_id']]
 
 if args.no_notifications:
     send_updates = "none"
@@ -66,34 +71,45 @@ for session in sessions:
                 cmd = f"gcal.create_event({start_time.isoformat()}, {end_time.isoformat()}, {title}, {description}, {attendees}, send_updates={send_updates})"
                 print(f"Dry-run: would run {cmd}")
             else:
-                gcal.create_event(start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
-        elif args.update:
-            existing_events = gcal.get_events_by_date(start_time)
-            if len(existing_events) != 1:
-                print("Number of existing events found different than 1. Case not handled. Exiting")
-                exit(1)
+                event = gcal.create_event(start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
+                calendar.set_private_gcal_id(session['course_id'], session['start_date'], event['id'])
 
-            event_id = existing_events[0]['id']
+        elif args.update:
+            if session['private_gcal_id']:
+                event_id = session['private_gcal_id']
+            else:
+                existing_events = gcal.get_events_by_date(start_time)
+                if len(existing_events) != 1:
+                    print("Number of existing events found different than 1. Case not handled. Exiting")
+                    exit(1)
+                event_id = existing_events[0]['id']
+
             if args.dry_run:
                 cmd = f"gcal.update_event({event_id}, {start_time.isoformat()}, {end_time.isoformat()}, {title}, {description}, {attendees}, send_updates={send_updates})"
                 print(f"Dry-run: would run {cmd}")
             else:
                 gcal.update_event(event_id, start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
         elif args.delete:
-            existing_events = gcal.get_events_by_date(start_time)
-            if len(existing_events) != 1:
-                print("Number of existing events found different than 1. Case not handled. Exiting")
-                exit(1)
+            if session['private_gcal_id']:
+                event_id = session['private_gcal_id']
+            else:
+                existing_events = gcal.get_events_by_date(start_time)
+                if len(existing_events) != 1:
+                    print("Number of existing events found different than 1. Case not handled. Exiting")
+                    exit(1)
 
-            event_id = existing_events[0]['id']
+                event_id = existing_events[0]['id']
 
             if args.dry_run:
                 cmd = f"gcal.delete_event({event_id}, send_updates={send_updates})"
                 print(f"Dry-run: would run {cmd}")
             else:
                 gcal.delete_event(event_id, send_updates=send_updates)
+                calendar.set_private_gcal_id(session['course_id'], session['start_date'], '')
     except Exception as error:
         print(f"Error encountered when processing session {session}: %s" % error)
 
 
+if not args.dry_run:
+    calendar.update_spreadsheet()
 

--- a/gcal_events.py
+++ b/gcal_events.py
@@ -3,10 +3,10 @@ import os, argparse, datetime
 
 import interfaces.zoom.ZoomInterface as ZoomInterface
 import interfaces.google.GCalInterface as GCalInterface
+from CQORCcalendar import Calendar
 
 from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
-from common import get_events_from_sheet_calendar
 from common import Trainers
 
 parser = argparse.ArgumentParser()
@@ -36,7 +36,7 @@ zoom = ZoomInterface.ZoomInterface(config['zoom']['account_id'], config['zoom'][
 start_offset_minutes = int(config['google.calendar']['start_offset_minutes'])
 
 # get the events from the working calendar in the Google spreadsheets
-events = get_events_from_sheet_calendar(config, args)
+events = Calendar(config, args).get_all_sessions()
 
 # keep only events on the date listed
 if args.date:

--- a/interfaces/eventbrite/EventbriteInterface.py
+++ b/interfaces/eventbrite/EventbriteInterface.py
@@ -241,8 +241,51 @@ class EventbriteInterface(eb.Eventbrite):
             "purpose": "listing"
         }
 
-        get_structed_content = self._raise_or_ok(self.get(f"/events/{event_id}/structured_content/"))
-        version = int(get_structed_content["page_version_number"])
+        get_structured_content = self._raise_or_ok(self.get(f"/events/{event_id}/structured_content/"))
+        version = int(get_structured_content["page_version_number"])
+
+        return self._raise_or_ok(self.post(f"/events/{event_id}/structured_content/{version+1}/", data=obj))
+
+    # Note: This merely creates a generic webinar, not a Zoom connection
+    def update_webinar_url(self, event_id, webinar_url):
+        """
+        Update the event webinar module.
+
+        Parameters
+        ----------
+        event_id: Event id to update
+        webinar_url: Webinar URL
+
+        Returns
+        -------
+        None
+        """
+        obj = {
+            "modules": [{
+                "type": "webinar",
+                "data": {
+                    "webinar_url":{
+                        "text": "my webinar",
+                        "url": f"{webinar_url}"
+                    },
+                    "image":{
+                        "type":"image",
+                        "image_id":"63131771"
+                    },
+                    "title":{
+                        "text": "Optional Title",
+                    },
+                    "instructions":{
+                        "text": "Instructions to join the webinar",
+                    }
+                }
+                }],
+            "publish": "true",
+            "purpose": "digital_content"
+        }
+
+        get_structured_content = self._raise_or_ok(self.get(f"/events/{event_id}/structured_content/?purpose=digital_content"))
+        version = int(get_structured_content["page_version_number"])
 
         return self._raise_or_ok(self.post(f"/events/{event_id}/structured_content/{version+1}/", data=obj))
 

--- a/public_gcal_events.py
+++ b/public_gcal_events.py
@@ -4,7 +4,7 @@ import os, argparse, datetime
 import interfaces.google.GCalInterface as GCalInterface
 import interfaces.eventbrite.EventbriteInterface as Eventbrite
 import yaml
-from CQORCcalendar import Calendar
+import CQORCcalendar
 
 from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
@@ -12,6 +12,7 @@ from common import actualize_repo
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--date", metavar=ISO_8061_FORMAT, type=valid_date, help="Generate for the first event on this date")
+parser.add_argument("--course_id", help="Generate events for the course specified by the course_id")
 parser.add_argument("--config_dir", default=".", help="Directory that holds the configuration files")
 parser.add_argument("--secrets_dir", default=".", help="Directory that holds the configuration files")
 parser.add_argument("--all", default=False, action='store_true', help="Act for all events")
@@ -44,11 +45,15 @@ def get_eb_event_by_date(query_date):
     return eb_event
 
 # get the events from the working calendar in the Google spreadsheets
-sessions = Calendar(config, args).get_all_sessions()
+calendar = CQORCcalendar.Calendar(config, args)
+sessions = calendar.get_all_sessions()
 
-# keep only events on the date listed
+# keep only sessions on the date listed
 if args.date:
     sessions = [session for session in sessions if args.date.date().isoformat() in session['start_date']]
+# keep only sessions for the given course_id
+if args.course_id:
+    sessions = [session for session in sessions if args.course_id == session['course_id']]
 
 send_updates = "none"
 
@@ -72,7 +77,7 @@ for session in sessions:
             eb_event = eb.get_event(session['eventbrite_id'])
         else:
             eb_event = get_eb_event_by_date(start_time.date())
-
+        eb_event_id = None
         if eb_event:
             eb_event_id = eb_event['id']
 
@@ -111,41 +116,51 @@ Plan:
 Plan:
 {plan}
 """
-
         if args.create:
             if args.dry_run:
                 cmd = f"gcal.create_event({start_time.isoformat()}, {end_time.isoformat()}, {title}, {description}, {attendees}, send_updates={send_updates})"
                 print(f"Dry-run: would run {cmd}")
             else:
-                gcal.create_event(start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
-        elif args.update:
-            existing_events = gcal.get_events_by_date(start_time)
-            if len(existing_events) != 1:
-                print("Number of existing events found different than 1. Case not handled. Exiting")
-                exit(1)
+                event = gcal.create_event(start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
+                calendar.set_public_gcal_id(session['course_id'], session['start_date'], event['id'])
 
-            event_id = existing_events[0]['id']
+        elif args.update:
+            if session['public_gcal_id']:
+                event_id = session['public_gcal_id']
+            else:
+                existing_events = gcal.get_events_by_date(start_time)
+                if len(existing_events) != 1:
+                    print("Number of existing events found different than 1. Case not handled. Exiting")
+                    exit(1)
+                event_id = existing_events[0]['id']
+
             if args.dry_run:
                 cmd = f"gcal.update_event({event_id}, {start_time.isoformat()}, {end_time.isoformat()}, {title}, {description}, {attendees}, send_updates={send_updates})"
                 print(f"Dry-run: would run {cmd}")
             else:
                 gcal.update_event(event_id, start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
         elif args.delete:
-            existing_events = gcal.get_events_by_date(start_time)
-            if len(existing_events) != 1:
-                print("Number of existing events found different than 1. Case not handled. Exiting")
-                exit(1)
+            if session['public_gcal_id']:
+                event_id = session['public_gcal_id']
+            else:
+                existing_events = gcal.get_events_by_date(start_time)
+                if len(existing_events) != 1:
+                    print("Number of existing events found different than 1. Case not handled. Exiting")
+                    exit(1)
 
-            event_id = existing_events[0]['id']
+                event_id = existing_events[0]['id']
 
             if args.dry_run:
                 cmd = f"gcal.delete_event({event_id}, send_updates={send_updates})"
                 print(f"Dry-run: would run {cmd}")
             else:
                 gcal.delete_event(event_id, send_updates=send_updates)
+                calendar.set_public_gcal_id(session['course_id'], session['start_date'], '')
 
     except Exception as e:
         print(f"Error encountered when processing session {session}: {e}")
 
 
+if not args.dry_run:
+    calendar.update_spreadsheet()
 

--- a/public_gcal_events.py
+++ b/public_gcal_events.py
@@ -4,10 +4,10 @@ import os, argparse, datetime
 import interfaces.google.GCalInterface as GCalInterface
 import interfaces.eventbrite.EventbriteInterface as Eventbrite
 import yaml
+from CQORCcalendar import Calendar
 
 from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
-from common import get_events_from_sheet_calendar
 from common import actualize_repo
 
 parser = argparse.ArgumentParser()
@@ -44,7 +44,7 @@ def get_eb_event_by_date(query_date):
     return eb_event
 
 # get the events from the working calendar in the Google spreadsheets
-events = get_events_from_sheet_calendar(config, args)
+events = Calendar(config, args).get_all_sessions()
 
 # keep only events on the date listed
 if args.date:

--- a/public_gcal_events.py
+++ b/public_gcal_events.py
@@ -44,32 +44,35 @@ def get_eb_event_by_date(query_date):
     return eb_event
 
 # get the events from the working calendar in the Google spreadsheets
-events = Calendar(config, args).get_all_sessions()
+sessions = Calendar(config, args).get_all_sessions()
 
 # keep only events on the date listed
 if args.date:
-    events = [event for event in events if args.date.date().isoformat() in event['start_date']]
+    sessions = [session for session in sessions if args.date.date().isoformat() in session['start_date']]
 
 send_updates = "none"
 
 # ensure descriptions are up to date
 actualize_repo(config["descriptions"]["repo_url"], config["descriptions"]["local_repo"])
 
-for event in events:
+for session in sessions:
     try:
-        if len(event['code']):
+        if len(session['code']):
             # Read the description from the repo
-            with open(os.path.join(config["descriptions"]["local_repo"], f"{event['code']}-{event['langue']}.yaml")) as f:
+            with open(os.path.join(config["descriptions"]["local_repo"], f"{session['code']}-{session['langue']}.yaml")) as f:
                 event_description = yaml.safe_load(f)
         else:
             event_description = None
-            print("Empty workshop code, skipping updating description")        
+            print("Empty workshop code, skipping updating description")
 
-        start_time = to_iso8061(event['start_date'])
-        end_time = to_iso8061(event['end_date'])
-        duration = int(event['hours'])
+        start_time = to_iso8061(session['start_date'])
+        end_time = to_iso8061(session['end_date'])
 
-        eb_event = get_eb_event_by_date(start_time.date())
+        if session['eventbrite_id']:
+            eb_event = eb.get_event(session['eventbrite_id'])
+        else:
+            eb_event = get_eb_event_by_date(start_time.date())
+
         if eb_event:
             eb_event_id = eb_event['id']
 
@@ -84,7 +87,7 @@ for event in events:
 {event_description['description']}"""
             plan = "\n* ".join([''] + event_description['plan'])
         else:
-            title = event['title']
+            title = session['title']
             plan = "-"
             summary = "-"
 
@@ -92,7 +95,7 @@ for event in events:
         if eb_event:
             title = eb_event['name']['text']
 
-        if event['langue'] == "FR":
+        if session['langue'] == "FR":
             description = f"""Inscriptions: {registration_url}
 
 {summary}
@@ -109,56 +112,40 @@ Plan:
 {plan}
 """
 
-        # events on two days
-        two_day_events = False
-        if start_time.date() != end_time.date():
-            two_day_events = True
-            duration = duration/2.
+        if args.create:
+            if args.dry_run:
+                cmd = f"gcal.create_event({start_time.isoformat()}, {end_time.isoformat()}, {title}, {description}, {attendees}, send_updates={send_updates})"
+                print(f"Dry-run: would run {cmd}")
+            else:
+                gcal.create_event(start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
+        elif args.update:
+            existing_events = gcal.get_events_by_date(start_time)
+            if len(existing_events) != 1:
+                print("Number of existing events found different than 1. Case not handled. Exiting")
+                exit(1)
 
-        original_start_time = start_time
-        original_end_time = end_time
+            event_id = existing_events[0]['id']
+            if args.dry_run:
+                cmd = f"gcal.update_event({event_id}, {start_time.isoformat()}, {end_time.isoformat()}, {title}, {description}, {attendees}, send_updates={send_updates})"
+                print(f"Dry-run: would run {cmd}")
+            else:
+                gcal.update_event(event_id, start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
+        elif args.delete:
+            existing_events = gcal.get_events_by_date(start_time)
+            if len(existing_events) != 1:
+                print("Number of existing events found different than 1. Case not handled. Exiting")
+                exit(1)
 
-        for date in set([start_time.date(), end_time.date()]):
-            if date == original_start_time.date():
-                start_time = original_start_time
-                end_time = original_start_time + datetime.timedelta(hours=duration)
-            elif date == original_end_time.date():
-                start_time = original_end_time - datetime.timedelta(hours=duration)
-                end_time = original_end_time
+            event_id = existing_events[0]['id']
 
-            if args.create:
-                if args.dry_run:
-                    cmd = f"gcal.create_event({start_time.isoformat()}, {end_time.isoformat()}, {title}, {description}, {attendees}, send_updates={send_updates})"
-                    print(f"Dry-run: would run {cmd}")
-                else:
-                    gcal.create_event(start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
-            elif args.update:
-                existing_events = gcal.get_events_by_date(start_time)
-                if len(existing_events) != 1:
-                    print("Number of existing events found different than 1. Case not handled. Exiting")
-                    exit(1)
+            if args.dry_run:
+                cmd = f"gcal.delete_event({event_id}, send_updates={send_updates})"
+                print(f"Dry-run: would run {cmd}")
+            else:
+                gcal.delete_event(event_id, send_updates=send_updates)
 
-                event_id = existing_events[0]['id']
-                if args.dry_run:
-                    cmd = f"gcal.update_event({event_id}, {start_time.isoformat()}, {end_time.isoformat()}, {title}, {description}, {attendees}, send_updates={send_updates})"
-                    print(f"Dry-run: would run {cmd}")
-                else:
-                    gcal.update_event(event_id, start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
-            elif args.delete:
-                existing_events = gcal.get_events_by_date(start_time)
-                if len(existing_events) != 1:
-                    print("Number of existing events found different than 1. Case not handled. Exiting")
-                    exit(1)
-
-                event_id = existing_events[0]['id']
-
-                if args.dry_run:
-                    cmd = f"gcal.delete_event({event_id}, send_updates={send_updates})"
-                    print(f"Dry-run: would run {cmd}")
-                else:
-                    gcal.delete_event(event_id, send_updates=send_updates)
     except Exception as e:
-        print(f"Error encountered when processing event {event}: {e}")
+        print(f"Error encountered when processing session {session}: {e}")
 
 
 

--- a/slack_manager.py
+++ b/slack_manager.py
@@ -70,7 +70,7 @@ for course in courses:
         if not slack_channel_name:
             slack_channel_name = eval('f' + repr(config['global']['slack_channel_template']))
             slack_channel_name = slack_channel_name.lower()
-            calendar.set_slack_channel(first_session['course_id'])
+            calendar.set_slack_channel(first_session['course_id'], slack_channel_name)
 
         if args.create:
             if args.dry_run:
@@ -176,9 +176,10 @@ for course in courses:
                     slack.post_to_channel(slack_channel_name, message['message'], message['time'])
 
     except Exception as e:
-        print(f"Error encountered when processing event {event}: \n\n{e}")
+        print(f"Error encountered when processing course {course}: \n\n{e}")
 
 
-calendar.update_spreadsheet()
+if not args.dry_run:
+    calendar.update_spreadsheet()
 
 

--- a/slack_manager.py
+++ b/slack_manager.py
@@ -3,10 +3,10 @@ import os, argparse, datetime
 
 import interfaces.zoom.ZoomInterface as ZoomInterface
 import interfaces.slack.SlackInterface as SlackInterface
+from CQORCcalendar import Calendar
 
 from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
-from common import get_events_from_sheet_calendar
 from common import get_survey_link
 from common import Trainers
 
@@ -38,7 +38,7 @@ zoom = ZoomInterface.ZoomInterface(config['zoom']['account_id'], config['zoom'][
 
 
 # get the events from the working calendar in the Google spreadsheets
-events = get_events_from_sheet_calendar(config, args)
+events = Calendar(config, args).get_all_sessions()
 
 # keep only events on the date listed
 if args.date:

--- a/slack_manager.py
+++ b/slack_manager.py
@@ -139,13 +139,7 @@ for course in courses:
             else:
                 print(f"{slack.list_channel_scheduled_messages(slack_channel_name)}")
 
-        original_start_time = start_time
-        original_end_time = end_time
         if args.messages:
-            # events on two days
-            if start_time.date() != end_time.date():
-                duration = duration/2.
-
             magic_castle_link = slack.get_channel_bookmark_link(slack_channel_name, "Magic Castle")
             zoom_user_link = slack.get_channel_bookmark_link(slack_channel_name, "Zoom URL Participants")
             survey_link = slack.get_channel_bookmark_link(slack_channel_name, "Survey")
@@ -159,15 +153,11 @@ for course in courses:
             messages = []
             for prefix in message_prefixes:
                 text = eval('f' + repr(config['slack'][f'{prefix}_template']))
-                for date in set([start_time.date(), end_time.date()]):
-                    if date == original_start_time.date():
-                        start_time = original_start_time
-                        end_time = original_start_time + datetime.timedelta(hours=duration)
-                    elif date == original_end_time.date():
-                        start_time = original_end_time - datetime.timedelta(hours=duration)
-                        end_time = original_end_time
+                for session in course['sessions']:
+                    start_time = to_iso8061(session['start_date'])
+                    end_time = to_iso8061(session['end_date'])
 
-                    if date == original_start_time.date() or config['slack'][f'{prefix}_multidays'] == "True":
+                    if start_time == to_iso8061(first_session['start_date']) or config['slack'][f'{prefix}_multidays'] == "True":
                         time = start_time
                         if f'{prefix}_offset_start' in config['slack']:
                             time = start_time + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset_start']))

--- a/zoom_attendance_to_eventbrite.py
+++ b/zoom_attendance_to_eventbrite.py
@@ -4,6 +4,7 @@ import os, argparse, datetime
 import interfaces.eventbrite.EventbriteInterface as Eventbrite
 import interfaces.zoom.ZoomInterface as ZoomInterface
 import interfaces.slack.SlackInterface as SlackInterface
+import CQORCcalendar
 
 from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
@@ -14,6 +15,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--eventbrite_id", help="EventBrite event id")
 parser.add_argument("--zoom_id", help="EventBrite event id")
 parser.add_argument("--date", metavar=ISO_8061_FORMAT, type=valid_date, help="Generate for the first event on this date")
+parser.add_argument("--course_id", help="ID of the course")
 parser.add_argument("--config_dir", default=".", help="Directory that holds the configuration files")
 parser.add_argument("--secrets_dir", default=".", help="Directory that holds the configuration files")
 parser.add_argument("--noslack", default=False, action='store_true', help="Do not post to Slack")
@@ -23,6 +25,12 @@ args = parser.parse_args()
 # read configuration files
 global_config = get_config(args)
 
+# get the events from the working calendar in the Google spreadsheets
+calendar = CQORCcalendar.Calendar(config, args)
+course = None
+if args.course_id:
+    course = calendar[args.course_id]
+
 # initialize Zoom interface
 zoom_user = global_config['zoom']['user']
 zoom = ZoomInterface.ZoomInterface(global_config['zoom']['account_id'], global_config['zoom']['client_id'], global_config['zoom']['client_secret'], global_config['global']['timezone'], zoom_user)
@@ -30,6 +38,8 @@ zoom = ZoomInterface.ZoomInterface(global_config['zoom']['account_id'], global_c
 webinars = []
 if args.zoom_id:
     webinars = zoom.get_webinars(ids = [int(args.zoom_id)])
+elif course:
+    webinars = zoom.get_webinar(ids = [int(course[0]['zoom_id'])])
 elif args.date:
     webinars = zoom.get_webinars(date = to_iso8061(args.date).date())
 
@@ -78,6 +88,8 @@ eb = Eventbrite.EventbriteInterface(global_config['eventbrite']['api_key'])
 eb_event = None
 if args.eventbrite_id:
     eb_event = eb.get_event(args.eventbrite_id)
+elif course:
+    eb_event = eb.get_event(course[0]['eventbrite_id'])
 else:
     eb_events = eb.get_events(global_config['eventbrite']['organization_id'], time_filter="past", flattened=True, order_by="start_desc")
     todays_events = []

--- a/zoom_manager.py
+++ b/zoom_manager.py
@@ -86,7 +86,7 @@ for course in courses:
         if args.delete_webinar:
             print(f"Deleting webinar {webinar['id']}")
             zoom.delete_webinar(webinar['id'])
-            calendar.set_zoom_id(first_session['id'], '')
+            calendar.set_zoom_id(first_session['course_id'], '')
             exit(0)
 
         if args.update_webinar_panelists or args.update_webinar:

--- a/zoom_manager.py
+++ b/zoom_manager.py
@@ -31,9 +31,6 @@ args = parser.parse_args()
 config = get_config(args)
 trainers = Trainers(config['global']['trainers_db'])
 
-secrets_dir = os.environ.get('CQORC_SECRETS_DIR', args.secrets_dir)
-credentials_file = config['google']['credentials_file']
-credentials_file_path = os.path.join(secrets_dir, credentials_file)
 timezone = config['google.calendar'].get('timezone', config['global']['timezone'])
 zoom_user = config['zoom']['user']
 zoom = ZoomInterface.ZoomInterface(config['zoom']['account_id'], config['zoom']['client_id'], config['zoom']['client_secret'], config['global']['timezone'], zoom_user)
@@ -133,22 +130,6 @@ for course in courses:
             pp = pprint.PrettyPrinter(indent=4)
             print("Webinar:")
             pp.pprint(webinar)
-
-#        if args.create_webinar:
-#            if args.dry_run:
-#                cmd = f"slack.create_channel({slack_channel_name})"
-#                print(f"Dry-run: would run {cmd}")
-#            else:
-#                slack.create_channel(slack_channel_name)
-
-#        if args.invites:
-#            if args.dry_run:
-#                cmd = f"slack.invite_to_channel({slack_channel_name}, {attendees})"
-#                print(f"Dry-run: would run {cmd}")
-#            else:
-#                slack.invite_to_channel(slack_channel_name, attendees)
-
-
 
 #    except Exception as e:
 #        print(f"Error encountered when processing event {event}: \n\n{e}")

--- a/zoom_manager.py
+++ b/zoom_manager.py
@@ -3,8 +3,8 @@ import os, argparse, datetime
 import pprint
 
 import interfaces.zoom.ZoomInterface as ZoomInterface
+import CQORCcalendar
 
-from CQORCcalendar import Calendar
 from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
 from common import Trainers
@@ -38,7 +38,8 @@ zoom = ZoomInterface.ZoomInterface(config['zoom']['account_id'], config['zoom'][
 
 
 # get the courses from the working calendar in the Google spreadsheets
-courses = Calendar(config, args).get_courses()
+calendar = CQORCcalendar.Calendar(config, args)
+courses = calendar.get_courses()
 
 # keep only courses that start on the date listed
 if args.date:
@@ -65,6 +66,7 @@ for course in courses:
             webinars = zoom.get_webinars(date = start_time.date())
             if webinars:
                 webinar = zoom.get_webinar(webinar_id = webinars[0]['id'])
+                calendar.set_zoom_id(first_session['course_id'], webinar['id'])
 
         if args.update_webinar_panelists or args.update_webinar:
             panelists = zoom.get_panelists(webinar['id'])
@@ -130,5 +132,6 @@ for course in courses:
 #    except Exception as e:
 #        print(f"Error encountered when processing event {event}: \n\n{e}")
 
+calendar.update_spreadsheet()
 
 

--- a/zoom_manager.py
+++ b/zoom_manager.py
@@ -4,9 +4,9 @@ import pprint
 
 import interfaces.zoom.ZoomInterface as ZoomInterface
 
+from CQORCcalendar import Calendar
 from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
-from common import get_events_from_sheet_calendar
 from common import Trainers
 from common import get_survey_link
 
@@ -38,7 +38,7 @@ zoom = ZoomInterface.ZoomInterface(config['zoom']['account_id'], config['zoom'][
 
 
 # get the events from the working calendar in the Google spreadsheets
-events = get_events_from_sheet_calendar(config, args)
+events = Calendar(config, args).get_all_sessions()
 
 # keep only events on the date listed
 if args.date:


### PR DESCRIPTION
- Introduction de la classe Calendar, qui lit et met à jour la feuille de calcul d'événements
- Ajout du "eventbrite_manager.py" basé sur "create_event.py", mais avec le même type de paramètres d'entrées que les autres scripts (--course_id, --date, --create, --update, --delete)
- Mis à jour "gcal_events.py" pour gérer les événements multi-session et stocker les ID dans la feuille de calcul d'événements
- Mis à jour "public_gcal_events.py" pour gérer les événements multi-session et stocker les ID dans la feuille de calcul d'événements
- Mis à jour "slack_manager.py" pour gérer les événements multi-session et stocker les noms de canaux dans la feuille de calcul d'événements
- Ajout d'une fonction à EventbriteInterface pour mettre à jour l'URL de webinaire, mais inutile car non connecté au Zoom
- Mis à jour "zoom_attendance_to_eventbrite.py" pour gérer les événements multi-session et plusieurs événements sur le même jour
- Mis à jour "zoom_manager.py" pour gérer les événements multi-session et stocker les ID dans la feuille de calcul d'événements