### PR TITLE
Ajouter un événement pour le cours ou pour le post-mortem

### DIFF
--- a/CQORCcalendar.py
+++ b/CQORCcalendar.py
@@ -55,20 +55,10 @@ class Calendar:
         for session in self.courses[course_id]['sessions']:
             session['slack_channel'] = slack_channel
 
-    def set_public_gcal_id(self, course_id, session_start_date, public_gcal_id):
+    def set_gcal_id(self, course_id, session_start_date, gcal_id,  gcal_id_type=""):
         for session in self.courses[course_id]['sessions']:
             if session['start_date'] == session_start_date:
-                session['public_gcal_id'] = public_gcal_id
-
-    def set_private_gcal_id(self, course_id, session_start_date, private_gcal_id):
-        for session in self.courses[course_id]['sessions']:
-            if session['start_date'] == session_start_date:
-                session['private_gcal_id'] = private_gcal_id
-    
-    def set_post_mortem_private_gcal_id(self, course_id, session_start_date, post_mortem_private_gcal_id):
-        for session in self.courses[course_id]['sessions']:
-            if session['start_date'] == session_start_date:
-                session['post_mortem_private_gcal_id'] = post_mortem_private_gcal_id
+                session[gcal_id_type] = gcal_id
 
     def update_spreadsheet(self):
         values = [self.header]

--- a/CQORCcalendar.py
+++ b/CQORCcalendar.py
@@ -64,6 +64,11 @@ class Calendar:
         for session in self.courses[course_id]['sessions']:
             if session['start_date'] == session_start_date:
                 session['private_gcal_id'] = private_gcal_id
+    
+    def set_post_mortem_private_gcal_id(self, course_id, session_start_date, post_mortem_private_gcal_id):
+        for session in self.courses[course_id]['sessions']:
+            if session['start_date'] == session_start_date:
+                session['post_mortem_private_gcal_id'] = post_mortem_private_gcal_id
 
     def update_spreadsheet(self):
         values = [self.header]

--- a/config.cfg
+++ b/config.cfg
@@ -31,6 +31,7 @@ message_bienvenue_template = Bienvenue sur le canal pour la formation {course_co
 
 [google.calendar]
 start_offset_minutes = -10
+google_meet_link = https://meet.google.com/syg-djdn-nkm
 
 [descriptions]
 repo_url=git@github.com:calculquebec/eventbrite_descriptions.git

--- a/gcal_events.py
+++ b/gcal_events.py
@@ -1,5 +1,5 @@
 #!/bin/env python3
-import os, argparse, datetime
+import os, argparse
 
 import interfaces.zoom.ZoomInterface as ZoomInterface
 import interfaces.google.GCalInterface as GCalInterface
@@ -9,6 +9,8 @@ from common import valid_date, to_iso8061, ISO_8061_FORMAT, get_config
 from common import extract_course_code_from_title
 from common import get_trainer_keys
 from common import Trainers
+from collections import Counter
+from datetime import datetime, timedelta
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--date", metavar=ISO_8061_FORMAT, type=valid_date, help="Generate for the first event on this date")
@@ -43,6 +45,23 @@ start_offset_minutes = int(config['google.calendar']['start_offset_minutes'])
 calendar = CQORCcalendar.Calendar(config, args)
 sessions = calendar.get_all_sessions()
 
+# list courses on multiple sessions.
+counter = Counter(item["course_id"] for item in sessions)
+
+# Identify course_ids that appear more than once
+duplicate_ids = {course_id for course_id, count in counter.items() if count > 1}
+
+# Select the session with the latest end_date for each duplicate course_id for the given course_id
+latest_sessions_duplicate_course = {}
+for item in sessions:
+    course_id = item["course_id"]
+    if course_id in duplicate_ids:
+        current_end = datetime.strptime(item["end_date"], "%Y-%m-%d %H:%M:%S")
+        if course_id not in latest_sessions_duplicate_course or current_end > datetime.strptime(latest_sessions_duplicate_course[course_id]["end_date"], "%Y-%m-%d %H:%M:%S"):
+            latest_sessions_duplicate_course[course_id] = item
+latest_session = list(latest_sessions_duplicate_course.values())
+latest_session = [session for session in latest_session if args.course_id == session['course_id']]
+
 # keep only sessions on the date listed
 if args.date:
     sessions = [session for session in sessions if args.date.date().isoformat() in session['start_date']]
@@ -62,77 +81,85 @@ for session in sessions:
         zoom_link = webinar['join_url']
         event_dict = {
             "course": {
-                "status": args.course,
                 "title": f"{session['code']} - {session['title']}",
-                "start_time": to_iso8061(session['start_date']) + datetime.timedelta(minutes=start_offset_minutes),
+                "start_time": to_iso8061(session['start_date']) + timedelta(minutes=start_offset_minutes),
                 "end_time": to_iso8061(session['end_date']),
                 "description": f"""Voyez l'invitation envoyée par Zoom, ou encore le canal sur Slack pour les liens""",
-                "session_id": 'private_gcal_id',
-                "set_function": calendar.set_private_gcal_id
+                "session_id": 'private_gcal_id'
             },
             "post_mortem": {
-                "status": args.post_mortem,
                 "title": f"{session['code']} - {session['title']} - post mortem",
-                "start_time": to_iso8061(session['end_date']),
-                "end_time":  to_iso8061(session['end_date']) + datetime.timedelta(minutes=30),
+                "start_time": to_iso8061(session['start_date']),
+                "end_time":  to_iso8061(session['end_date']) + timedelta(minutes=30),
                 "description": f"""Voici le lien Zoom <a href="{zoom_link}">{zoom_link}</a>, ou encore le canal sur Slack pour les liens et le google doc post mortem""",
-                "session_id": 'post_mortem_private_gcal_id',
-                "set_function": calendar.set_post_mortem_private_gcal_id
+                "session_id": 'post_mortem_private_gcal_id'
             }
         }
+        event_list = []
+        if args.course:
+            event_list.append(event_dict['course'])
+        if args.post_mortem:
+            event_list.append(event_dict['post_mortem'])
 
         if args.create:
-            for key, value in event_dict.items():
-                if value['status']:
-                    if session[value['session_id']]:
-                        event_id = session[value['session_id']]
-                        print(f"Calendar ID found: {session[value['session_id']]}, not creating a new event")
+            for event_type in event_list:
+                if event_type['session_id'] == 'private_gcal_id' or (event_type['session_id'] == 'post_mortem_private_gcal_id' and event_type['start_time'] == to_iso8061(latest_session[0]['start_date'])):
+                    if session[event_type['session_id']]:
+                        event_id = session[event_type['session_id']]
+                        print(f"Calendar ID found: {session[event_type['session_id']]}, not creating a new event")
                     elif args.dry_run:
-                        cmd = f"gcal.create_event({value['start_time'].isoformat()}, {value['end_time'].isoformat()}, {value['title']}, {value['description']}, {attendees}, send_updates={send_updates})"
+                        cmd = f"gcal.create_event({event_type['start_time'].isoformat()}, {event_type['end_time'].isoformat()}, {event_type['title']}, {event_type['description']}, {attendees}, send_updates={send_updates})"
                         print(f"Dry-run: would run {cmd}")
                     else:
-                        event = gcal.create_event(value['start_time'].isoformat(), value['end_time'].isoformat(), value['title'], value['description'], attendees, send_updates=send_updates)                            
-                        value['set_function'](session['course_id'], session['start_date'], event['id'])
+                        event = gcal.create_event(event_type['start_time'].isoformat(), event_type['end_time'].isoformat(), event_type['title'], event_type['description'], attendees, send_updates=send_updates)                            
+                        calendar.set_gcal_id(session['course_id'], session['start_date'], event['id'], event_type['session_id'])
                         calendar.update_spreadsheet()
 
         elif args.update:
-            for key, value in event_dict.items():
-                if value['status']:
-                    if session[value['session_id']]:
-                        event_id = session[value['session_id']]
-                    else:
-                        existing_events = gcal.get_events_by_date(value['start_time'])
-                        if len(existing_events) != 1:
-                            print("Number of existing events found different than 1. Case not handled. Exiting")
-                            exit(1)
-                        event_id = existing_events[0]['id']
+            for event_type in event_list:
+                if session[event_type['session_id']]:
+                    event_id = session[event_type['session_id']]
+                else:
+                    if event_type['session_id'] == 'private_gcal_id':
+                        print(f"This private Google Calendar event (course id : {session['course_id']}, start date: {event_type['start_time'].isoformat()}) cannot be updated because it has not been created.")  
+                    elif event_type['session_id'] == 'post_mortem_private_gcal_id' and event_type['start_time'] != to_iso8061(latest_session[0]['start_date']):
+                        print(f"This event (course id : {session['course_id']}, start date: {event_type['start_time'].isoformat()}) has no post-mortem Google Calendar because it is not the last session of the event. It couldn't be updated.")
+                    elif event_type['session_id'] == 'post_mortem_private_gcal_id' and event_type['start_time'] == to_iso8061(latest_session[0]['start_date']):
+                        print(f"This post mortem event (course id : {session['course_id']}, start date: {event_type['start_time'].isoformat()}) cannot be updated because it has not been created.")
+                    event_id = ""
 
-                    if args.dry_run:
-                        cmd = f"gcal.update_event({event_id}, {value['start_time'].isoformat()}, {value['end_time'].isoformat()}, {value['title']}, {value['description']}, {attendees}, send_updates={send_updates})"
-                        print(f"Dry-run: would run {cmd}")
-                    else:
-                        gcal.update_event(event_id, value['start_time'].isoformat(), value['end_time'].isoformat(), value['title'], value['description'], attendees, send_updates=send_updates)
+                if args.dry_run:
+                    if not event_id:
+                        print("Please note that this Google Calendar event has not been created.")
+                    cmd = f"gcal.update_event({event_id}, {event_type['start_time'].isoformat()}, {event_type['end_time'].isoformat()}, {event_type['title']}, {event_type['description']}, {attendees}, send_updates={send_updates})"
+                    print(f"Dry-run: would run {cmd}")
+                else:
+                    if event_id:
+                        gcal.update_event(event_id, event_type['start_time'].isoformat(), event_type['end_time'].isoformat(), event_type['title'], event_type['description'], attendees, send_updates=send_updates)
 
         elif args.delete:
-            for key, value in event_dict.items():
-                if value['status']:
-                    if session[value['session_id']]:
-                        event_id = session[value['session_id']]
-                    else:
-                        existing_events = gcal.get_events_by_date(value['start_time'])
-                        if len(existing_events) != 1:
-                            print("Number of existing events found different than 1. Case not handled. Exiting")
-                            exit(1)
+            for event_type in event_list:
+                if session[event_type['session_id']]:
+                    event_id = session[event_type['session_id']]
+                else:
+                    if event_type['session_id'] == 'private_gcal_id':
+                        print(f"This private Google Calendar event (course id : {session['course_id']}, start date: {event_type['start_time'].isoformat()}) cannot be deleted because it does not exist.")  
+                    elif event_type['session_id'] == 'post_mortem_private_gcal_id' and event_type['start_time'] != to_iso8061(latest_session[0]['start_date']):
+                        print(f"This event (course id : {session['course_id']}, start date: {event_type['start_time'].isoformat()}) has no post-mortem Google Calendar entry because it is not the last session of the event. It cannot be deleted because it does not exist.")
+                    elif event_type['session_id'] == 'post_mortem_private_gcal_id' and event_type['start_time'] == to_iso8061(latest_session[0]['start_date']):
+                        print(f"This post-mortem event (course id : {session['course_id']}, start date: {event_type['start_time'].isoformat()}) cannot be deleted because it does not exist.")
+                    event_id = ""
 
-                        event_id = existing_events[0]['id']
-
-                    if args.dry_run:
-                        cmd = f"gcal.delete_event({event_id}, send_updates={send_updates})"
-                        print(f"Dry-run: would run {cmd}")
-                    else:
+                if args.dry_run:
+                    if not event_id:
+                        print("Please note that this Google Canlendar event has not been created.")
+                    cmd = f"gcal.delete_event({event_id}, send_updates={send_updates})"
+                    print(f"Dry-run: would run {cmd}")
+                else:
+                    if event_id:
                         gcal.delete_event(event_id, send_updates=send_updates)
-                        value['set_function'](session['course_id'], session['start_date'], '')
-                        calendar.update_spreadsheet()   
+                        calendar.set_gcal_id(session['course_id'], session['start_date'], '', event_type['session_id'])
+                        calendar.update_spreadsheet()
 
     except Exception as error:
         print(f"Error encountered when processing session {session}: %s" % error)

--- a/gcal_events.py
+++ b/gcal_events.py
@@ -78,7 +78,8 @@ for session in sessions:
     try:
         attendees = [trainers.calendar_email(key) for key in get_trainer_keys(session, ['instructor', 'host', 'assistants'])]
         webinar = zoom.get_webinar(webinar_id = session['zoom_id'])
-        zoom_link = webinar['join_url']
+        google_meet_link = config['google.calendar']['google_meet_link']
+        post_mortem_doc_link = config['slack']['post_mortem_link']
         event_dict = {
             "course": {
                 "title": f"{session['code']} - {session['title']}",
@@ -91,7 +92,7 @@ for session in sessions:
                 "title": f"{session['code']} - {session['title']} - post mortem",
                 "start_time": to_iso8061(session['start_date']),
                 "end_time":  to_iso8061(session['end_date']) + timedelta(minutes=30),
-                "description": f"""Voici le lien Zoom <a href="{zoom_link}">{zoom_link}</a>, ou encore le canal sur Slack pour les liens et le google doc post mortem""",
+                "description": f"""Voici le lien Google Meet <a href="{google_meet_link}">{google_meet_link}</a> et le Google doc post-mortem <a href="{post_mortem_doc_link}">{post_mortem_doc_link}</a>. Le google doc post-mortem se retrouve aussi sur le canal Slack""",
                 "session_id": 'post_mortem_private_gcal_id'
             }
         }

--- a/public_gcal_events.py
+++ b/public_gcal_events.py
@@ -129,7 +129,7 @@ Plan:
                 print(f"Dry-run: would run {cmd}")
             else:
                 event = gcal.create_event(start_time.isoformat(), end_time.isoformat(), title, description, attendees, send_updates=send_updates)
-                calendar.set_public_gcal_id(session['course_id'], session['start_date'], event['id'])
+                calendar.set_gcal_id(session['course_id'], session['start_date'], event['id'], "public_gcal_id")
                 calendar.update_spreadsheet()
 
         elif args.update:
@@ -163,7 +163,7 @@ Plan:
                 print(f"Dry-run: would run {cmd}")
             else:
                 gcal.delete_event(event_id, send_updates=send_updates)
-                calendar.set_public_gcal_id(session['course_id'], session['start_date'], '')
+                calendar.set_gcal_id(session['course_id'], session['start_date'], '', "public_gcal_id")
                 calendar.update_spreadsheet()
 
     except Exception as e:


### PR DESCRIPTION
J'ai ajouté un paramètre --course et --post_mortem qui peuvent être ajouté indépendamment mais obligatoirement pour la création, update ou delete.

Pour tester:
Dans le calendrier de travail:
Utiliser l'événement numéro id 32. Ajouter nom pour instructor, host, assistant. (J'avais utilisé Hélène partout)

python3 zoom_manager.py --course_id 32 --create

python3 eventbrite_manager.py --course_id 32 --create

Tester le script gcal_events.py : 
python3 gcal_events.py --course_id 32 --create --post_mortem 
ou
python3 gcal_events.py --course_id 32 --create --course
ou
python3 gcal_events.py --course_id 32 --create --course --post_mortem

python3 gcal_events.py --course_id 32 --update --post_mortem
ou
python3 gcal_events.py --course_id 32 --update --course
ou
python3 gcal_events.py --course_id 32 --update --course --post_mortem

python3 gcal_events.py --course_id 32 --delete --post_mortem
ou
python3 gcal_events.py --course_id 32 --delete --course
ou
python3 gcal_events.py --course_id 32 --delete --course --post_mortem

On aura un lien vers le zoom pour l'évènement post_mortem dans le message de l'événement calendrier.

