### PR TITLE
Message automatique pour la création et la destruction des grappes

### DIFF
--- a/CQORCcalendar.py
+++ b/CQORCcalendar.py
@@ -33,6 +33,10 @@ class Calendar:
 
     def get_courses(self):
         return self.courses.values()
+    
+    def get_equipe_techno(self, course_id):
+        for session in self.courses[course_id]['sessions']:
+            return session['equipe_techno']
 
     def keys(self):
         return self.courses.keys()

--- a/config.cfg
+++ b/config.cfg
@@ -20,6 +20,7 @@ ignored_email_domains = calculquebec.ca,calcul-quebec.ca
 message_survey_offset_end = -60
 message_survey_template = <!channel>: N'oubliez pas de poster le sondage: {survey_link}
 message_survey_multidays = True
+
 # message_2 in secrets config file
 message_bienvenue_offset_now = 1
 message_bienvenue_multidays = False
@@ -28,6 +29,21 @@ message_bienvenue_template = Bienvenue sur le canal pour la formation {course_co
    Je suis votre robot assistant et je posterai des messages pertinents à des moments pertinents (ou du moins, je l'espère).
    Des signets avec les liens utiles ont été ajoutés au canal.
 
+message_creationOui_template = C'est la responsabilité de {analysts_tagged} de créer la grappe pour ce cours.
+message_creationOui_offset1_now = 1
+message_creationOui_multidays = False
+
+message_creationNon_template = La grappe a déjà été créé par {analysts_tagged}. Elle sera réutilisée pour ce cours.
+message_creationNon_offset2_now = 1
+message_creationNon_multidays = False
+
+message_destructionOui_template = {analysts_tagged}, vous pouvez détruire la grappe.
+message_destructionOui_offset1_24h =  1440
+message_destructionOui_multidays = False
+
+message_destructionNon_template = {analysts_tagged}, la grappe sera réutilisée pour un autre cours. Merci de ne pas la détruire.
+message_destructionNon_offset2_24h = 1440
+message_destructionNon_multidays = False
 
 [google.calendar]
 start_offset_minutes = -10

--- a/config.cfg
+++ b/config.cfg
@@ -30,20 +30,24 @@ message_bienvenue_template = Bienvenue sur le canal pour la formation {course_co
    Des signets avec les liens utiles ont été ajoutés au canal.
 
 message_creationOui_template = C'est la responsabilité de {analysts_tagged} de créer la grappe pour ce cours.
-message_creationOui_offset1_now = 1
+message_creationOui_offset_now = 1
 message_creationOui_multidays = False
+message_creationOui_condition = session['creation_grappe'] == "oui"
 
 message_creationNon_template = La grappe a déjà été créé par {analysts_tagged}. Elle sera réutilisée pour ce cours.
-message_creationNon_offset2_now = 1
+message_creationNon_offset_now = 1
 message_creationNon_multidays = False
+message_creationNon_condition = session['creation_grappe'] == "non"
 
 message_destructionOui_template = {analysts_tagged}, vous pouvez détruire la grappe.
-message_destructionOui_offset1_24h =  1440
+message_destructionOui_offset_end =  1440
 message_destructionOui_multidays = False
+message_destructionOui_condition = session['destruction_grappe'] == "oui"
 
 message_destructionNon_template = {analysts_tagged}, la grappe sera réutilisée pour un autre cours. Merci de ne pas la détruire.
-message_destructionNon_offset2_24h = 1440
+message_destructionNon_offset_end = 1440
 message_destructionNon_multidays = False
+message_destructionNon_condition = session['destruction_grappe'] == "non"
 
 [google.calendar]
 start_offset_minutes = -10

--- a/slack_manager.py
+++ b/slack_manager.py
@@ -167,7 +167,24 @@ for course in courses:
 
                         messages += [{'time': time, 'message': text}]
 
-                    if config['slack']
+                    if session['creation_grappe'] == "oui":
+                        time = datetime.datetime.now()
+                        message = f"C'est la responsabilité de {analysts} de créer la grappe pour ce cours."
+                        messages += [{'time': time, 'message': text}]
+                    else:
+                        time = datetime.datetime.now()
+                        message = f"La grappe a déjà été créé par {analysts}. Elle sera réutilisée pour ce cours."
+                        messages += [{'time': time, 'message': text}]
+                    
+                    if session['destruction_grappe'] == "oui":
+                        time = end_time + datetime.timedelta(hours=24)
+                        message = f"{analysts}, vous pouvez détruire la grappe."
+                        messages += [{'time': time, 'message': text}]
+                    else:
+                        time = end_time + datetime.timedelta(hours=24)
+                        message = f"{analysts}, la grappe sera réutilisée pour un autre cours. Merci de ne pas la détruire. "
+                        messages += [{'time': time, 'message': text}]
+
 
 
             for message in messages:

--- a/slack_manager.py
+++ b/slack_manager.py
@@ -142,7 +142,6 @@ for course in courses:
             magic_castle_link = slack.get_channel_bookmark_link(slack_channel_name, "Magic Castle")
             zoom_user_link = slack.get_channel_bookmark_link(slack_channel_name, "Zoom URL Participants")
             survey_link = slack.get_channel_bookmark_link(slack_channel_name, "Survey")
-
             message_prefixes = []
             for key in config['slack']:
                 key_parts = key.split('_')
@@ -155,6 +154,7 @@ for course in courses:
                 for session in course['sessions']:
                     start_time = to_iso8061(session['start_date'])
                     end_time = to_iso8061(session['end_date'])
+                    analysts = calendar.get_equipe_techno(session['course_id'])
 
                     if start_time == to_iso8061(first_session['start_date']) or config['slack'][f'{prefix}_multidays'] == "True":
                         time = start_time
@@ -166,6 +166,9 @@ for course in courses:
                             time = datetime.datetime.now() + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset_now']))
 
                         messages += [{'time': time, 'message': text}]
+
+                    if config['slack']
+
 
             for message in messages:
                 if args.dry_run:

--- a/slack_manager.py
+++ b/slack_manager.py
@@ -167,29 +167,29 @@ for course in courses:
             analysts_tagged = format_tag(equipe_techno_id_list)
 
             for prefix in message_prefixes:
+                # Evalutate text message
                 text = eval('f' + repr(config['slack'][f'{prefix}_template']))
+
                 for session in course['sessions']:
+                    # Evaluate the condition
+                    if f'{prefix}_condition' in config['slack']:
+                        if not eval(config['slack'][f'{prefix}_condition']):
+                            continue
+
                     start_time = to_iso8061(session['start_date'])
                     end_time = to_iso8061(session['end_date'])
+
                     if start_time == to_iso8061(first_session['start_date']) or config['slack'][f'{prefix}_multidays'] == "True":
-                        time = None
+                        time = start_time
+                        # Applying offsets
                         if f'{prefix}_offset_start' in config['slack']:
                             time = start_time + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset_start']))
                         elif f'{prefix}_offset_end' in config['slack']:
                             time = end_time + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset_end']))
                         elif f'{prefix}_offset_now' in config['slack']:
                             time = datetime.datetime.now() + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset_now']))
-                        elif f'{prefix}_offset1_now' in config['slack'] and session['creation_grappe'] == "oui":
-                            time = datetime.datetime.now() + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset1_now']))
-                        elif f'{prefix}_offset2_now' in config['slack'] and session['creation_grappe'] == "non":
-                            time = datetime.datetime.now() + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset2_now']))
-                        elif f'{prefix}_offset1_24h' in config['slack'] and session['destruction_grappe'] == "oui":
-                            time = datetime.datetime.now() + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset1_24h']))
-                        elif f'{prefix}_offset2_24h' in config['slack'] and session['destruction_grappe'] == "non":
-                            time = datetime.datetime.now() + datetime.timedelta(minutes=int(config['slack'][f'{prefix}_offset2_24h']))
 
-                        if time is not None:
-                            messages += [{'time': time, 'message': text}]
+                        messages += [{'time': time, 'message': text}]
 
             for message in messages:
                 if args.dry_run:

--- a/slack_manager.py
+++ b/slack_manager.py
@@ -83,7 +83,7 @@ for course in courses:
                 calendar.set_slack_channel(first_session['course_id'], slack_channel_name)
 
         if args.invites:
-            attendees = [trainers.slack_email(key) for key in get_trainer_keys(course, ['instructor', 'host', 'assistants'])]
+            attendees = [trainers.slack_email(key) for key in get_trainer_keys(course, ['instructor', 'host', 'assistants', 'equipe_techno'])]
 
             if args.dry_run:
                 cmd = f"slack.invite_to_channel({slack_channel_name}, {attendees})"


### PR DESCRIPTION
Ajout automatique des messages de création et destruction des grappes via le canal slack du cours. Voir le calendrier de travail pour l'ajout de 3 colonnes: équipe_techno, création_grappe et destruction_grappe. Si création_grappe est à "oui", on envoie le message de création de la grappe à la création du canal Slack. Si création_grappe est à "non", c'est que la grappe a déjà été créée et sera réutilisée pour le cours en question. Un message est envoyé pour spécifier le tout à la création du canal Slack. Si destruction_grappe est à "oui", un message est envoyé pour détruire la grappe 24h après la fin du cours. Si destruction_grappe est à "non", un message est envoyé pour ne pas détruire la grappe 24h après la fin du cours.

**À faire**: ajouter équipe_techno au canal Slack lors de la création du canal. 