### PR TITLE
Modification message slack si réutilise la grappe.

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -34,7 +34,7 @@ message_creationOui_offset_now = 1
 message_creationOui_multidays = False
 message_creationOui_condition = session['creation_grappe'] == "oui"
 
-message_creationNon_template = La grappe a déjà été créé par {analysts_tagged}. Elle sera réutilisée pour ce cours.
+message_creationNon_template = {analysts_tagged}, la grappe a déjà été créée pour un cours précédent. Elle sera réutilisée pour ce cours.
 message_creationNon_offset_now = 1
 message_creationNon_multidays = False
 message_creationNon_condition = session['creation_grappe'] == "non"


### PR DESCRIPTION
Le message si on réutilise la grappe n'est pas adéquat.

J'ai changé: La grappe a déjà été créé par {analysts_tagged}. Elle sera réutilisée pour ce cours.

Pour: {analysts_tagged}, la grappe a déjà été créée pour un cours précédent. Elle sera réutilisée pour ce cours.