### PR TITLE
Ajout course_id

### DIFF
--- a/create_certificate.py
+++ b/create_certificate.py
@@ -17,9 +17,9 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 
 import interfaces.eventbrite.EventbriteInterface as Eventbrite
+import CQORCcalendar
 
 from common import get_config
-from common import to_iso8061
 
 ATTESTATION_CQ_TEMPLATE = "Attestation_CQ_{}_{}_{}.pdf"
 
@@ -27,7 +27,7 @@ ATTESTATION_CQ_TEMPLATE = "Attestation_CQ_{}_{}_{}.pdf"
 """
 Usage:
 
-python3 create_certificate.py --event_id 778466443087
+python3 create_certificate.py --course_id 7
 """
 
 
@@ -391,7 +391,7 @@ if __name__ == '__main__':
     parser.add_argument("--order_id", default=None, help="Attendee order identification number")
     parser.add_argument("--language", default=None, choices=['fr', 'en'],  help="Event language. en = english ; fr = french")
     parser.add_argument("--certificate_dir", default="./certificates", help="Directory to write the certificates.")
-    parser.add_argument("--event_id", help="EventBrite event id", required=True)
+    parser.add_argument("--course_id", help="Course ID from the calendar spreadsheet", required=True)
     parser.add_argument("--certificate_svg_tplt_dir",default="./secrets/Attestation_template", help="Directory that holds certificate templates.")
     parser.add_argument("--gmail_user", help="Gmail username", type=str, default=None)
     parser.add_argument("--gmail_password", help="Gmail password", type=str, default=None)
@@ -409,8 +409,12 @@ if __name__ == '__main__':
     # Initialize EventBrite interface:
     eb = Eventbrite.EventbriteInterface(global_config['eventbrite']['api_key'])
 
+    # Resolve course_id to EventBrite event id via the calendar:
+    calendar = CQORCcalendar.Calendar(global_config, args)
+    eventbrite_id = calendar[args.course_id]['sessions'][0]['eventbrite_id']
+
     # Get event information:
-    eb_event = eb.get_event(args.event_id)
+    eb_event = eb.get_event(eventbrite_id)
 
     # Get information for attendees that participated, that is that have their status to `checked in` or `attended`:
     eb_attendees = eb.get_event_attendees_present(eb_event['id'], fields = ['title', 'email', 'first_name', 'last_name', 'status', 'name', 'order_id'])


### PR DESCRIPTION
Ajout de `course_id` au lieu de `event_id` pour lancer le script `create_certificate.py` pour faciliter et uniformiser l'utilisation.